### PR TITLE
WIP: upsilon/Mirakurun 変更点まとめ

### DIFF
--- a/bin/cli.sh
+++ b/bin/cli.sh
@@ -75,23 +75,23 @@ mirakurun_config () {
 }
 
 mirakurun_log () {
-  pm2 logs mirakurun-server "$@" && return 0
+  sudo -u mirakurun pm2 logs mirakurun-server "$@" && return 0
 }
 
 mirakurun_status () {
-  pm2 status && return 0
+  sudo -u mirakurun pm2 status && return 0
 }
 
 mirakurun_start () {
-  pm2 start processes.json && return 0
+  sudo -u mirakurun pm2 start processes.json && return 0
 }
 
 mirakurun_stop () {
-  pm2 stop processes.json && return 0
+  sudo -u mirakurun pm2 stop processes.json && return 0
 }
 
 mirakurun_restart() {
-  pm2 restart processes.json && return 0
+  sudo -u mirakurun pm2 restart processes.json && return 0
 }
 
 mirakurun_version () {

--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -42,11 +42,13 @@ if (process.platform === "linux" || process.platform === "darwin") {
 
     const prefix = "/usr/local";
     const configDir = path.join(prefix, "etc/mirakurun");
-    const dataDir = path.join(prefix, "var/db/mirakurun");
-    const logDir = path.join(prefix, "var/log");
+    const dataDir = path.join(prefix, "var/lib/mirakurun");
+    const runDir = path.join(prefix, "var/run/mirakurun");
+    const logDir = path.join(prefix, "var/log/mirakurun");
 
     child_process.execSync(`mkdir -vp ${configDir}`);
     child_process.execSync(`mkdir -vp ${dataDir}`);
+    child_process.execSync(`mkdir -vp ${runDir}`);
     child_process.execSync(`mkdir -vp ${logDir}`);
 
     const serverConfigPath = path.join(configDir, "server.yml");

--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -65,6 +65,13 @@ if (process.platform === "linux" || process.platform === "darwin") {
         copyFileSync("config/channels.yml", channelsConfigPath);
     }
 
+    child_process.execSync('id mirakurun 2>&1 > /dev/null || useradd -r -G video -d /usr/local/var/lib/mirakurun -s /bin/false mirakurun');
+
+    child_process.execSync('chown -R mirakurun:mirakurun /usr/local/etc/mirakurun');
+    child_process.execSync('chown -R mirakurun:mirakurun /usr/local/var/log/mirakurun');
+    child_process.execSync('chown -R mirakurun:mirakurun /usr/local/var/run/mirakurun');
+    child_process.execSync('chown -R mirakurun:mirakurun /usr/local/var/lib/mirakurun');
+
     // pm2
 
     if (process.env.DOCKER === "YES") {
@@ -86,7 +93,7 @@ if (process.platform === "linux" || process.platform === "darwin") {
     }
 
     try {
-        child_process.execSync(`pm2 startup`, {
+        child_process.execSync("pm2 startup -u mirakurun --hp /usr/local/var/lib/mirakurun", {
             stdio: [
                 null,
                 process.stdout,
@@ -97,7 +104,7 @@ if (process.platform === "linux" || process.platform === "darwin") {
         console.log("Caution: `pm2 startup` has failed. you can try fix yourself.");
     }
 
-    child_process.execSync("pm2 start processes.json", {
+    child_process.execSync("sudo -u mirakurun pm2 start processes.json", {
         stdio: [
             null,
             process.stdout,
@@ -105,7 +112,7 @@ if (process.platform === "linux" || process.platform === "darwin") {
         ]
     });
 
-    child_process.execSync("pm2 save", {
+    child_process.execSync("sudo -u mirakurun pm2 save", {
         stdio: [
             null,
             process.stdout,

--- a/bin/preuninstall.js
+++ b/bin/preuninstall.js
@@ -26,7 +26,7 @@ if (process.platform === "linux" || process.platform === "darwin") {
         process.exit(0);
     }
 
-    execSync("pm2 stop processes.json", {
+    execSync("sudo -u mirakurun pm2 stop processes.json", {
         stdio: [
             null,
             process.stdout,
@@ -34,7 +34,7 @@ if (process.platform === "linux" || process.platform === "darwin") {
         ]
     });
 
-    execSync("pm2 delete processes.json", {
+    execSync("sudo -u mirakurun pm2 delete processes.json", {
         stdio: [
             null,
             process.stdout,

--- a/config/server.yml
+++ b/config/server.yml
@@ -2,7 +2,7 @@
 logLevel: 2
 
 # path: <string>
-path: /var/run/mirakurun.sock
+path: /usr/local/var/run/mirakurun/mirakurun.sock
 
 # port: <number>
 # You can change this if port conflicted.

--- a/processes.json
+++ b/processes.json
@@ -4,16 +4,16 @@
       "name": "mirakurun-server",
       "script": "lib/server.js",
       "node_args" : "--max_old_space_size=256",
-      "error_file": "/usr/local/var/log/mirakurun.stderr.log",
-      "out_file": "/usr/local/var/log/mirakurun.stdout.log",
+      "error_file": "/usr/local/var/log/mirakurun/stderr.log",
+      "out_file": "/usr/local/var/log/mirakurun/stdout.log",
       "merge_logs": true,
-      "pid_file": "/usr/local/var/run/mirakurun.pid",
+      "pid_file": "/usr/local/var/run/mirakurun/pid",
       "exec_mode": "fork",
       "autorestart": true,
       "env": {
         "NODE_ENV": "production",
-        "LOG_STDOUT": "/usr/local/var/log/mirakurun.stdout.log",
-        "LOG_STDERR": "/usr/local/var/log/mirakurun.stderr.log"
+        "LOG_STDOUT": "/usr/local/var/log/mirakurun/stdout.log",
+        "LOG_STDERR": "/usr/local/var/log/mirakurun/stderr.log"
       }
     }
   ]

--- a/src/Mirakurun/TSFilter.ts
+++ b/src/Mirakurun/TSFilter.ts
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 import * as stream from "stream";
+import * as customize from "./customize";
 import * as log from "./log";
 import epg from "./epg";
 import status from "./status";
@@ -503,7 +504,7 @@ export default class TSFilter extends stream.Duplex {
             const m = service.descriptors.length;
             for (let j = 0; j < m; j++) {
                 if (service.descriptors[j].descriptor_tag === 0x48) {
-                    name = new aribts.TsChar(service.descriptors[j].service_name_char).decode();
+                    name = customize.convertFullWidthToHalf(new aribts.TsChar(service.descriptors[j].service_name_char).decode());
                     type = service.descriptors[j].service_type;
                 }
 

--- a/src/Mirakurun/customize.ts
+++ b/src/Mirakurun/customize.ts
@@ -18,3 +18,33 @@
  */
 
 "use strict";
+
+const fullwidthReplaceTable = {
+    "０": "0", "１": "1", "２": "2", "３": "3", "４": "4",
+    "５": "5", "６": "6", "７": "7", "８": "8", "９": "9", "　": " ",
+    "Ａ": "A", "Ｂ": "B", "Ｃ": "C", "Ｄ": "D", "Ｅ": "E",
+    "Ｆ": "F", "Ｇ": "G", "Ｈ": "H", "Ｉ": "I", "Ｊ": "J",
+    "Ｋ": "K", "Ｌ": "L", "Ｍ": "M", "Ｎ": "N", "Ｏ": "O",
+    "Ｐ": "P", "Ｑ": "Q", "Ｒ": "R", "Ｓ": "S", "Ｔ": "T",
+    "Ｕ": "U", "Ｖ": "V", "Ｗ": "W", "Ｘ": "X", "Ｙ": "Y", "Ｚ": "Z",
+    "ａ": "a", "ｂ": "b", "ｃ": "c", "ｄ": "d", "ｅ": "e",
+    "ｆ": "f", "ｇ": "g", "ｈ": "h", "ｉ": "i", "ｊ": "j",
+    "ｋ": "k", "ｌ": "l", "ｍ": "m", "ｎ": "n", "ｏ": "o",
+    "ｐ": "p", "ｑ": "q", "ｒ": "r", "ｓ": "s", "ｔ": "t",
+    "ｕ": "u", "ｖ": "v", "ｗ": "w", "ｘ": "x", "ｙ": "y", "ｚ": "z"
+};
+
+export function convertFullWidthToHalf(text: string): string {
+    let result = "";
+
+    for (let c of text) {
+        const replacement = fullwidthReplaceTable[c];
+        if (replacement !== undefined) {
+            c = replacement;
+        }
+
+        result += c;
+    }
+
+    return result;
+}

--- a/src/Mirakurun/customize.ts
+++ b/src/Mirakurun/customize.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (C) 2017 Kimura Youichi <kim.upsilon@bucyou.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @license AGPL-3.0
+ */
+
+"use strict";

--- a/src/Mirakurun/epg.ts
+++ b/src/Mirakurun/epg.ts
@@ -78,7 +78,7 @@ const SAMPLING_RATE = {
     7: 48000
 };
 
-interface EventState {
+export interface EventState {
     version: VersionState;
     program: ProgramItem;
 
@@ -267,53 +267,7 @@ class EPG extends stream.Writable {
 
                     // extended_event
                     case 0x4E:
-                        if (state.extended.version !== eit.version_number) {
-                            state.extended.version = eit.version_number;
-                            state.extended._descs = new Array(d.last_descriptor_number + 1);
-                            state.extended._done = false;
-                        } else if (state.extended._done === true) {
-                            break;
-                        }
-
-                        if (state.extended._descs[d.descriptor_number] === undefined) {
-                            state.extended._descs[d.descriptor_number] = d.items;
-
-                            let comp = true;
-                            for (const descs of state.extended._descs) {
-                                if (descs === undefined) {
-                                    comp = false;
-                                    break;
-                                }
-                            }
-                            if (comp === false) {
-                                break;
-                            }
-
-                            const extended: any = {};
-
-                            let current = "";
-                            for (const descs of state.extended._descs) {
-                                for (const desc of descs) {
-                                    const key = desc.item_description_length === 0
-                                                ? current
-                                                : new TsChar(desc.item_description_char).decode();
-                                    current = key;
-
-                                    const char = new TsChar(desc.item_char).decode();
-                                    if (extended[key] === undefined) {
-                                        extended[key] = char;
-                                    } else {
-                                        extended[key] += char;
-                                    }
-                                }
-                            }
-
-                            state.program.update({
-                                extended: extended
-                            });
-
-                            state.extended._done = true; // done
-                        }
+                        customize.updateEventStateExtended(state, eit, d);
 
                         break;
 

--- a/src/Mirakurun/epg.ts
+++ b/src/Mirakurun/epg.ts
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 import * as stream from "stream";
+import * as customize from "./customize";
 import * as log from "./log";
 import * as db from "./db";
 import _ from "./_";
@@ -258,8 +259,8 @@ class EPG extends stream.Writable {
                         state.short.text_char = d.text_char;
 
                         state.program.update({
-                            name: new TsChar(d.event_name_char).decode(),
-                            description: new TsChar(d.text_char).decode()
+                            name: customize.convertFullWidthToHalf(new TsChar(d.event_name_char).decode()),
+                            description: customize.convertFullWidthToHalf(new TsChar(d.text_char).decode())
                         });
 
                         break;

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,8 +42,8 @@ process.on("uncaughtException", err => {
 setEnv("SERVER_CONFIG_PATH", "/usr/local/etc/mirakurun/server.yml");
 setEnv("TUNERS_CONFIG_PATH", "/usr/local/etc/mirakurun/tuners.yml");
 setEnv("CHANNELS_CONFIG_PATH", "/usr/local/etc/mirakurun/channels.yml");
-setEnv("SERVICES_DB_PATH", "/usr/local/var/db/mirakurun/services.json");
-setEnv("PROGRAMS_DB_PATH", "/usr/local/var/db/mirakurun/programs.json");
+setEnv("SERVICES_DB_PATH", "/usr/local/var/lib/mirakurun/services.json");
+setEnv("PROGRAMS_DB_PATH", "/usr/local/var/lib/mirakurun/programs.json");
 
 if (process.platform === "linux") {
     execSync(`renice -n -10 -p ${ process.pid }`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,12 +13,6 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-if (process.platform !== "win32") {
-    if (process.getuid() !== 0) {
-        console.error("root please.");
-        process.exit(1);
-    }
-}
 
 import { execSync } from "child_process";
 import _ from "./Mirakurun/_";
@@ -44,11 +38,6 @@ setEnv("TUNERS_CONFIG_PATH", "/usr/local/etc/mirakurun/tuners.yml");
 setEnv("CHANNELS_CONFIG_PATH", "/usr/local/etc/mirakurun/channels.yml");
 setEnv("SERVICES_DB_PATH", "/usr/local/var/lib/mirakurun/services.json");
 setEnv("PROGRAMS_DB_PATH", "/usr/local/var/lib/mirakurun/programs.json");
-
-if (process.platform === "linux") {
-    execSync(`renice -n -10 -p ${ process.pid }`);
-    execSync(`ionice -c 1 -n 7 -p ${ process.pid }`);
-}
 
 _.config.server = config.loadServer();
 _.config.channels = config.loadChannels();


### PR DESCRIPTION
master との差分を解説する用のPull Request

- [x] 放送局名・番組タイトルの全角英数字を半角に変換
  - 既存の録画予約ルールが適用されなくなるなど後方互換性を損なふ
- [x] 番組表に含まれる拡張形式イベント記述子 (番組詳細情報) のパースに対応
  - master ブランチの実装は、複数の記述子に分割されたテキストを正しくデコードできない事がある → upstreamで修正されたっぽい
- [x] Mirakurun を root ではなく mirakurun ユーザー (インストール時に作成する) で動作させる

某 Issue を見た人には関心があるかもしれませんが、私は Chinachu の Organization からブロックされてました。
このブランチは最早マージされない前提で書いてますが、使ひたい人が居るなら各自が適当に拾って行けばいいと思ひます。